### PR TITLE
Try using wrap for the row

### DIFF
--- a/client/cypress/e2e/inv.cy.ts
+++ b/client/cypress/e2e/inv.cy.ts
@@ -119,16 +119,20 @@ describe('Inventory', () => {
     cy.get('[data-cy="filter-type"]').type(Filters_Test.Type);
     cy.get('[data-cy="filter-size"]').type(Filters_Test.Size);
 
+    // Wait for debounce (300ms) + buffer to ensure the final API call is made
+    cy.wait(500);
     // Wait for the filtered results to load
     cy.wait('@filterInventory');
-    nextTick(1000);
 
-    cy.get(`[data-cy="inventory-table"]`).should('be.visible').then(() => {
-      cy.get(`[data-cy="inventory-item"]`).each(e => cy.wrap(e).should('include.text', Filters_Test.Item));
-      cy.get(`[data-cy="inventory-brand"]`).each(e => cy.wrap(e).should('include.text', Filters_Test.Brand));
-      cy.get(`[data-cy="inventory-type"]`).each(e => cy.wrap(e).should('include.text', Filters_Test.Type));
-      cy.get(`[data-cy="inventory-size"]`).each(e => cy.wrap(e).should('include.text', Filters_Test.Size));
-    });
+    // Ensure table has updated with filtered data
+    cy.get(`[data-cy="inventory-table"]`).should('be.visible');
+    cy.get(`[data-cy="inventory-item"]`).should('have.length.at.least', 1);
+
+    // Verify all visible items match the filters
+    cy.get(`[data-cy="inventory-item"]`).each(e => cy.wrap(e).should('include.text', Filters_Test.Item));
+    cy.get(`[data-cy="inventory-brand"]`).each(e => cy.wrap(e).should('include.text', Filters_Test.Brand));
+    cy.get(`[data-cy="inventory-type"]`).each(e => cy.wrap(e).should('include.text', Filters_Test.Type));
+    cy.get(`[data-cy="inventory-size"]`).each(e => cy.wrap(e).should('include.text', Filters_Test.Size));
   });
 
   it("Should be able to clear the filters via the button", () => {

--- a/client/cypress/e2e/inv.cy.ts
+++ b/client/cypress/e2e/inv.cy.ts
@@ -110,25 +110,38 @@ describe('Inventory', () => {
     page.getSidenavButton().click();
     page.getNavLink('Inventory').click();
     cy.url().should('match', /\/inventory$/);
-    cy.intercept('GET', `/api/inventory*`).as('filterInventory');
+
+    cy.get('[data-cy="filter-item"]').clear().type(Filters_Test.Item, {delay: 100});
 
     // Intercept the filtered API calls
-    cy.wait('@filterInventory');
+    //cy.wait('@filterInventory');
+    cy.get(`[data-cy="inventory-table"]`).should('be.visible');
+
+    // set up an intercept to wait for the filters to all be entered
+    cy.intercept({pathname:`/api/inventory`,
+      query: {
+        item: `${Filters_Test.Item}` ,
+        brand:`${Filters_Test.Brand}`,
+        type: `${Filters_Test.Type}` ,
+        size: `${Filters_Test.Size}`
+      }}).as('filterInventoryWithFilters');
 
     cy.get('[data-cy="filter-item"]').clear().type(Filters_Test.Item, {delay: 100});
     cy.get('[data-cy="filter-brand"]').clear().type(Filters_Test.Brand, {delay: 100});
     cy.get('[data-cy="filter-type"]').clear().type(Filters_Test.Type, {delay: 100});
     cy.get('[data-cy="filter-size"]').clear().type(Filters_Test.Size, {delay: 100});
 
-    cy.intercept('GET', `/api/inventory?item=${Filters_Test.Item}&brand=${Filters_Test.Brand}&type=${Filters_Test.Type}&size=${Filters_Test.Size}`).as('filterInventoryWithFilters');
+    // Intercept the filtered API calls (won't happen until debounce is done)
+    // so we won't need to explicitly wait for debounce
     cy.wait('@filterInventoryWithFilters');
+    cy.get(`[data-cy="inventory-table"]`).should('be.visible');
+
     // Wait for debounce (300ms) + buffer to ensure the final API call is made
-    cy.wait(500);
+    //cy.wait(500);
     // Wait for the filtered results to load
 
     // Ensure table has updated with filtered data
-    cy.get(`[data-cy="inventory-table"]`).should('be.visible');
-    cy.get(`[data-cy="inventory-item"]`).should('have.length.at.least', 1);
+    cy.get(`[data-cy="inventory-row"]`).should('have.length.at.least', 1);
 
     // Verify all visible items match the filters
     cy.get(`[data-cy="inventory-item"]`).each(e => cy.wrap(e).should('include.text', Filters_Test.Item));

--- a/client/cypress/e2e/inv.cy.ts
+++ b/client/cypress/e2e/inv.cy.ts
@@ -110,23 +110,25 @@ describe('Inventory', () => {
     page.getSidenavButton().click();
     page.getNavLink('Inventory').click();
     cy.url().should('match', /\/inventory$/);
+    cy.intercept('GET', `/api/inventory*`).as('filterInventory');
 
     // Intercept the filtered API calls
-    cy.intercept('GET', '/api/inventory*').as('filterInventory');
+    cy.wait('@filterInventory');
 
-    cy.get('[data-cy="filter-item"]').clear().type(Filters_Test.Item, {delay: 300});
-    cy.get('[data-cy="filter-brand"]').clear().type(Filters_Test.Brand, {delay: 300});
-    cy.get('[data-cy="filter-type"]').clear().type(Filters_Test.Type, {delay: 300});
-    cy.get('[data-cy="filter-size"]').clear().type(Filters_Test.Size, {delay: 300});
+    cy.get('[data-cy="filter-item"]').clear().type(Filters_Test.Item, {delay: 100});
+    cy.get('[data-cy="filter-brand"]').clear().type(Filters_Test.Brand, {delay: 100});
+    cy.get('[data-cy="filter-type"]').clear().type(Filters_Test.Type, {delay: 100});
+    cy.get('[data-cy="filter-size"]').clear().type(Filters_Test.Size, {delay: 100});
 
+    cy.intercept('GET', `/api/inventory?item=${Filters_Test.Item}&brand=${Filters_Test.Brand}&type=${Filters_Test.Type}&size=${Filters_Test.Size}`).as('filterInventoryWithFilters');
+    cy.wait('@filterInventoryWithFilters');
     // Wait for debounce (300ms) + buffer to ensure the final API call is made
     cy.wait(500);
     // Wait for the filtered results to load
-    cy.wait('@filterInventory');
 
     // Ensure table has updated with filtered data
     cy.get(`[data-cy="inventory-table"]`).should('be.visible');
-    cy.get(`[data-cy="inventory-row"]`).should('have.length.at.least', 1);
+    cy.get(`[data-cy="inventory-item"]`).should('have.length.at.least', 1);
 
     // Verify all visible items match the filters
     cy.get(`[data-cy="inventory-item"]`).each(e => cy.wrap(e).should('include.text', Filters_Test.Item));

--- a/client/cypress/e2e/inv.cy.ts
+++ b/client/cypress/e2e/inv.cy.ts
@@ -120,7 +120,7 @@ describe('Inventory', () => {
     cy.get('[data-cy="filter-size"]').type(Filters_Test.Size);
 
     // Wait for the filtered results to load
-    //cy.wait('@filterInventory');
+    cy.wait('@filterInventory');
     nextTick(1000);
 
     cy.contains(`[data-cy="inventory-item"]`, Filters_Test.Item) // Finds a cell with text Filters_Test.Item

--- a/client/cypress/e2e/inv.cy.ts
+++ b/client/cypress/e2e/inv.cy.ts
@@ -123,14 +123,14 @@ describe('Inventory', () => {
     //cy.wait('@filterInventory');
     nextTick(1000);
 
-    cy.get(`[data-cy="inventory-table"]`).then((table) => {
-      cy.wrap(table).get(`[data-cy="inventory-row"]`).then((row) => {
-        cy.wrap(row).get(`[data-cy="inventory-item"]`).should('contain', Filters_Test.Item);
-        cy.wrap(row).get(`[data-cy="inventory-brand"]`).should('contain', Filters_Test.Brand);
-        cy.wrap(row).get(`[data-cy="inventory-type"]`).should('contain', Filters_Test.Type);
-        cy.wrap(row).get(`[data-cy="inventory-size"]`).should('contain', Filters_Test.Size);
+    cy.contains(`[data-cy="inventory-item"]`, Filters_Test.Item) // Finds a cell with text Filters_Test.Item
+      .parent(`[data-cy="inventory-row"]`)             // Selects the parent row element
+      .within(() => {                // Scopes subsequent commands to this row
+        cy.get(`[data-cy="inventory-item"]`).should('contain', Filters_Test.Item);
+        cy.get(`[data-cy="inventory-brand"]`).should('contain', Filters_Test.Brand);
+        cy.get(`[data-cy="inventory-type"]`).should('contain', Filters_Test.Type);
+        cy.get(`[data-cy="inventory-size"]`).should('contain', Filters_Test.Size);
       });
-    });
   });
 
   it("Should be able to clear the filters via the button", () => {

--- a/client/cypress/e2e/inv.cy.ts
+++ b/client/cypress/e2e/inv.cy.ts
@@ -11,6 +11,10 @@ const Filters_Test = {
 }
 
 describe('Inventory', () => {
+  before(() => {
+    cy.task('seed:database');
+  });
+
   beforeEach(() => {
     // Intercept the API call before navigating
     cy.intercept('GET', '/api/inventory*').as('getInventory');
@@ -126,19 +130,15 @@ describe('Inventory', () => {
         size: `${Filters_Test.Size}`
       }}).as('filterInventoryWithFilters');
 
-    cy.get('[data-cy="filter-item"]').clear().type(Filters_Test.Item, {delay: 100});
-    cy.get('[data-cy="filter-brand"]').clear().type(Filters_Test.Brand, {delay: 100});
-    cy.get('[data-cy="filter-type"]').clear().type(Filters_Test.Type, {delay: 100});
-    cy.get('[data-cy="filter-size"]').clear().type(Filters_Test.Size, {delay: 100});
+    cy.get('[data-cy="filter-item"]').clear().type(Filters_Test.Item);
+    cy.get('[data-cy="filter-brand"]').clear().type(Filters_Test.Brand);
+    cy.get('[data-cy="filter-type"]').clear().type(Filters_Test.Type);
+    cy.get('[data-cy="filter-size"]').clear().type(Filters_Test.Size);
 
     // Intercept the filtered API calls (won't happen until debounce is done)
     // so we won't need to explicitly wait for debounce
     cy.wait('@filterInventoryWithFilters');
     cy.get(`[data-cy="inventory-table"]`).should('be.visible');
-
-    // Wait for debounce (300ms) + buffer to ensure the final API call is made
-    //cy.wait(500);
-    // Wait for the filtered results to load
 
     // Ensure table has updated with filtered data
     cy.get(`[data-cy="inventory-row"]`).should('have.length.at.least', 1);

--- a/client/cypress/e2e/inv.cy.ts
+++ b/client/cypress/e2e/inv.cy.ts
@@ -126,7 +126,7 @@ describe('Inventory', () => {
 
     // Ensure table has updated with filtered data
     cy.get(`[data-cy="inventory-table"]`).should('be.visible');
-    cy.get(`[data-cy="inventory-item"]`).should('have.length.at.least', 1);
+    cy.get(`[data-cy="inventory-row"]`).should('have.length.at.least', 1);
 
     // Verify all visible items match the filters
     cy.get(`[data-cy="inventory-item"]`).each(e => cy.wrap(e).should('include.text', Filters_Test.Item));

--- a/client/cypress/e2e/inv.cy.ts
+++ b/client/cypress/e2e/inv.cy.ts
@@ -123,15 +123,15 @@ describe('Inventory', () => {
     cy.wait('@filterInventory');
     nextTick(1000);
 
-    cy.get(`[data-cy="inventory-table"]`).should('be.visible');
+    cy.get(`[data-cy="inventory-table"]`).should('be.visible').within(() =>
 
-    cy.get(`[data-cy="inventory-row"]`)             // Selects the parent row element
-      .each(row => {            // Scopes subsequent commands to this row
-        cy.wrap(row).find(`[data-cy="inventory-item"]`).should('contain', Filters_Test.Item);
-        cy.wrap(row).find(`[data-cy="inventory-brand"]`).should('contain', Filters_Test.Brand);
-        cy.wrap(row).find(`[data-cy="inventory-type"]`).should('contain', Filters_Test.Type);
-        cy.wrap(row).find(`[data-cy="inventory-size"]`).should('contain', Filters_Test.Size);
-      });
+      cy.get(`[data-cy="inventory-row"]`)             // Selects the parent row element
+        .each(row => {            // Scopes subsequent commands to this row
+          cy.wrap(row).find(`[data-cy="inventory-item"]`).should('contain', Filters_Test.Item);
+          cy.wrap(row).find(`[data-cy="inventory-brand"]`).should('contain', Filters_Test.Brand);
+          cy.wrap(row).find(`[data-cy="inventory-type"]`).should('contain', Filters_Test.Type);
+          cy.wrap(row).find(`[data-cy="inventory-size"]`).should('contain', Filters_Test.Size);
+        }));
   });
 
   it("Should be able to clear the filters via the button", () => {

--- a/client/cypress/e2e/inv.cy.ts
+++ b/client/cypress/e2e/inv.cy.ts
@@ -123,17 +123,14 @@ describe('Inventory', () => {
     cy.wait('@filterInventory');
     //nextTick(1000);
 
-    cy.get(`[data-cy="inventory-table"]`).should('be.visible').within(() => {
-      cy.get('tbody').within(() => {
-        cy.get('tr')
-          .each(row => {  // Scopes subsequent commands to this row
-            cy.wrap(row).find(`[data-cy="inventory-item"]`).should('include.text', Filters_Test.Item);
-            cy.wrap(row).find(`[data-cy="inventory-brand"]`).should('include.text', Filters_Test.Brand);
-            cy.wrap(row).find(`[data-cy="inventory-type"]`).should('include.text', Filters_Test.Type);
-            cy.wrap(row).find(`[data-cy="inventory-size"]`).should('include.text', Filters_Test.Size);
-          });
-      });
-    });
+    cy.get(`[data-cy="inventory-table"]`).should('be.visible')
+      .find(`[data-cy="inventory-item"]`).should('include.text', Filters_Test.Item);
+    cy.get(`[data-cy="inventory-table"]`).should('be.visible')
+      .find(`[data-cy="inventory-brand"]`).should('include.text', Filters_Test.Brand);
+    cy.get(`[data-cy="inventory-table"]`).should('be.visible')
+      .find(`[data-cy="inventory-type"]`).should('include.text', Filters_Test.Type);
+    cy.get(`[data-cy="inventory-table"]`).should('be.visible')
+      .find(`[data-cy="inventory-size"]`).should('include.text', Filters_Test.Size);
   });
 
   it("Should be able to clear the filters via the button", () => {

--- a/client/cypress/e2e/inv.cy.ts
+++ b/client/cypress/e2e/inv.cy.ts
@@ -123,14 +123,12 @@ describe('Inventory', () => {
     cy.wait('@filterInventory');
     //nextTick(1000);
 
-    cy.get(`[data-cy="inventory-table"]`).should('be.visible')
-      .find(`[data-cy="inventory-item"]`).should('include.text', Filters_Test.Item);
-    cy.get(`[data-cy="inventory-table"]`).should('be.visible')
-      .find(`[data-cy="inventory-brand"]`).should('include.text', Filters_Test.Brand);
-    cy.get(`[data-cy="inventory-table"]`).should('be.visible')
-      .find(`[data-cy="inventory-type"]`).should('include.text', Filters_Test.Type);
-    cy.get(`[data-cy="inventory-table"]`).should('be.visible')
-      .find(`[data-cy="inventory-size"]`).should('include.text', Filters_Test.Size);
+    cy.get(`[data-cy="inventory-table"]`).should('be.visible').then(() => {
+      cy.get(`[data-cy="inventory-item"]`).each(e => cy.wrap(e).should('include.text', Filters_Test.Item));
+      cy.get(`[data-cy="inventory-brand"]`).each(e => cy.wrap(e).should('include.text', Filters_Test.Brand));
+      cy.get(`[data-cy="inventory-type"]`).each(e => cy.wrap(e).should('include.text', Filters_Test.Type));
+      cy.get(`[data-cy="inventory-size"]`).each(e => cy.wrap(e).should('include.text', Filters_Test.Size));
+    });
   });
 
   it("Should be able to clear the filters via the button", () => {

--- a/client/cypress/e2e/inv.cy.ts
+++ b/client/cypress/e2e/inv.cy.ts
@@ -123,11 +123,13 @@ describe('Inventory', () => {
     //cy.wait('@filterInventory');
     nextTick(1000);
 
-    page.getInventoryRow().then((row) => {
-      cy.wrap(row).get('[data-cy="inventory-item"]').should('contain', Filters_Test.Item);
-      cy.wrap(row).get('[data-cy="inventory-brand"]').should('contain', Filters_Test.Brand);
-      cy.wrap(row).get('[data-cy="inventory-type"]').should('contain', Filters_Test.Type);
-      cy.wrap(row).get('[data-cy="inventory-size"]').should('contain', Filters_Test.Size);
+    cy.get(`[data-cy="inventory-table"]`).then((table) => {
+      cy.wrap(table).get(`[data-cy="inventory-row"]`).then((row) => {
+        cy.wrap(row).get(`[data-cy="inventory-item"]`).should('contain', Filters_Test.Item);
+        cy.wrap(row).get(`[data-cy="inventory-brand"]`).should('contain', Filters_Test.Brand);
+        cy.wrap(row).get(`[data-cy="inventory-type"]`).should('contain', Filters_Test.Type);
+        cy.wrap(row).get(`[data-cy="inventory-size"]`).should('contain', Filters_Test.Size);
+      });
     });
   });
 

--- a/client/cypress/e2e/inv.cy.ts
+++ b/client/cypress/e2e/inv.cy.ts
@@ -120,16 +120,16 @@ describe('Inventory', () => {
     cy.get('[data-cy="filter-size"]').type(Filters_Test.Size);
 
     // Wait for the filtered results to load
-    cy.wait('@filterInventory');
+    //cy.wait('@filterInventory');
     nextTick(1000);
 
-    cy.contains(`[data-cy="inventory-item"]`, Filters_Test.Item) // Finds a cell with text Filters_Test.Item
+    cy.get(`[data-cy="inventory-item"]`) // Finds a cell that is an inventory-item
       .parent(`[data-cy="inventory-row"]`)             // Selects the parent row element
-      .within(() => {                // Scopes subsequent commands to this row
-        cy.get(`[data-cy="inventory-item"]`).should('contain', Filters_Test.Item);
-        cy.get(`[data-cy="inventory-brand"]`).should('contain', Filters_Test.Brand);
-        cy.get(`[data-cy="inventory-type"]`).should('contain', Filters_Test.Type);
-        cy.get(`[data-cy="inventory-size"]`).should('contain', Filters_Test.Size);
+      .each(row => {            // Scopes subsequent commands to this row
+        cy.wrap(row).find(`[data-cy="inventory-item"]`).should('contain', Filters_Test.Item);
+        cy.wrap(row).find(`[data-cy="inventory-brand"]`).should('contain', Filters_Test.Brand);
+        cy.wrap(row).find(`[data-cy="inventory-type"]`).should('contain', Filters_Test.Type);
+        cy.wrap(row).find(`[data-cy="inventory-size"]`).should('contain', Filters_Test.Size);
       });
   });
 

--- a/client/cypress/e2e/inv.cy.ts
+++ b/client/cypress/e2e/inv.cy.ts
@@ -123,11 +123,11 @@ describe('Inventory', () => {
     //cy.wait('@filterInventory');
     nextTick(1000);
 
-    page.getInventoryRow().first().within(() => {
-      cy.get('[data-cy="inventory-item"]').should('contain', Filters_Test.Item);
-      cy.get('[data-cy="inventory-brand"]').should('contain', Filters_Test.Brand);
-      cy.get('[data-cy="inventory-type"]').should('contain', Filters_Test.Type);
-      cy.get('[data-cy="inventory-size"]').should('contain', Filters_Test.Size);
+    page.getInventoryRow().then((row) => {
+      cy.wrap(row).get('[data-cy="inventory-item"]').should('contain', Filters_Test.Item);
+      cy.wrap(row).get('[data-cy="inventory-brand"]').should('contain', Filters_Test.Brand);
+      cy.wrap(row).get('[data-cy="inventory-type"]').should('contain', Filters_Test.Type);
+      cy.wrap(row).get('[data-cy="inventory-size"]').should('contain', Filters_Test.Size);
     });
   });
 

--- a/client/cypress/e2e/inv.cy.ts
+++ b/client/cypress/e2e/inv.cy.ts
@@ -125,7 +125,7 @@ describe('Inventory', () => {
 
     cy.get(`[data-cy="inventory-table"]`).should('be.visible').within(() => {
       cy.get('tbody').within(() => {
-        cy.get(`[data-cy="inventory-row"]`)
+        cy.get('tr')
           .each(row => {  // Scopes subsequent commands to this row
             cy.wrap(row).find(`[data-cy="inventory-item"]`).should('include.text', Filters_Test.Item);
             cy.wrap(row).find(`[data-cy="inventory-brand"]`).should('include.text', Filters_Test.Brand);

--- a/client/cypress/e2e/inv.cy.ts
+++ b/client/cypress/e2e/inv.cy.ts
@@ -121,17 +121,19 @@ describe('Inventory', () => {
 
     // Wait for the filtered results to load
     cy.wait('@filterInventory');
-    nextTick(1000);
+    //nextTick(1000);
 
-    cy.get(`[data-cy="inventory-table"]`).should('be.visible').within(() =>
-
-      cy.get(`[data-cy="inventory-row"]`)             // Selects the parent row element
-        .each(row => {            // Scopes subsequent commands to this row
-          cy.wrap(row).find(`[data-cy="inventory-item"]`).should('contain', Filters_Test.Item);
-          cy.wrap(row).find(`[data-cy="inventory-brand"]`).should('contain', Filters_Test.Brand);
-          cy.wrap(row).find(`[data-cy="inventory-type"]`).should('contain', Filters_Test.Type);
-          cy.wrap(row).find(`[data-cy="inventory-size"]`).should('contain', Filters_Test.Size);
-        }));
+    cy.get(`[data-cy="inventory-table"]`).should('be.visible').within(() => {
+      cy.get('tbody').within(() => {
+        cy.get(`[data-cy="inventory-row"]`)
+          .each(row => {  // Scopes subsequent commands to this row
+            cy.wrap(row).find(`[data-cy="inventory-item"]`).should('include.text', Filters_Test.Item);
+            cy.wrap(row).find(`[data-cy="inventory-brand"]`).should('include.text', Filters_Test.Brand);
+            cy.wrap(row).find(`[data-cy="inventory-type"]`).should('include.text', Filters_Test.Type);
+            cy.wrap(row).find(`[data-cy="inventory-size"]`).should('include.text', Filters_Test.Size);
+          });
+      });
+    });
   });
 
   it("Should be able to clear the filters via the button", () => {

--- a/client/cypress/e2e/inv.cy.ts
+++ b/client/cypress/e2e/inv.cy.ts
@@ -120,7 +120,7 @@ describe('Inventory', () => {
     cy.get('[data-cy="filter-size"]').type(Filters_Test.Size);
 
     // Wait for the filtered results to load
-    //cy.wait('@filterInventory');
+    cy.wait('@filterInventory');
     nextTick(1000);
 
     cy.get(`[data-cy="inventory-item"]`) // Finds a cell that is an inventory-item

--- a/client/cypress/e2e/inv.cy.ts
+++ b/client/cypress/e2e/inv.cy.ts
@@ -125,8 +125,7 @@ describe('Inventory', () => {
 
     cy.get(`[data-cy="inventory-table"]`).should('be.visible');
 
-    cy.get(`[data-cy="inventory-item"]`) // Finds a cell that is an inventory-item
-      .parent(`[data-cy="inventory-row"]`)             // Selects the parent row element
+    cy.get(`[data-cy="inventory-row"]`)             // Selects the parent row element
       .each(row => {            // Scopes subsequent commands to this row
         cy.wrap(row).find(`[data-cy="inventory-item"]`).should('contain', Filters_Test.Item);
         cy.wrap(row).find(`[data-cy="inventory-brand"]`).should('contain', Filters_Test.Brand);

--- a/client/cypress/e2e/inv.cy.ts
+++ b/client/cypress/e2e/inv.cy.ts
@@ -114,10 +114,10 @@ describe('Inventory', () => {
     // Intercept the filtered API calls
     cy.intercept('GET', '/api/inventory*').as('filterInventory');
 
-    cy.get('[data-cy="filter-item"]').type(Filters_Test.Item);
-    cy.get('[data-cy="filter-brand"]').type(Filters_Test.Brand);
-    cy.get('[data-cy="filter-type"]').type(Filters_Test.Type);
-    cy.get('[data-cy="filter-size"]').type(Filters_Test.Size);
+    cy.get('[data-cy="filter-item"]').clear().type(Filters_Test.Item, {delay: 100});
+    cy.get('[data-cy="filter-brand"]').clear().type(Filters_Test.Brand, {delay: 100});
+    cy.get('[data-cy="filter-type"]').clear().type(Filters_Test.Type, {delay: 100});
+    cy.get('[data-cy="filter-size"]').clear().type(Filters_Test.Size, {delay: 100});
 
     // Wait for debounce (300ms) + buffer to ensure the final API call is made
     cy.wait(500);

--- a/client/cypress/e2e/inv.cy.ts
+++ b/client/cypress/e2e/inv.cy.ts
@@ -121,7 +121,7 @@ describe('Inventory', () => {
 
     // Wait for the filtered results to load
     cy.wait('@filterInventory');
-    //nextTick(1000);
+    nextTick(1000);
 
     cy.get(`[data-cy="inventory-table"]`).should('be.visible').then(() => {
       cy.get(`[data-cy="inventory-item"]`).each(e => cy.wrap(e).should('include.text', Filters_Test.Item));

--- a/client/cypress/e2e/inv.cy.ts
+++ b/client/cypress/e2e/inv.cy.ts
@@ -114,10 +114,10 @@ describe('Inventory', () => {
     // Intercept the filtered API calls
     cy.intercept('GET', '/api/inventory*').as('filterInventory');
 
-    cy.get('[data-cy="filter-item"]').clear().type(Filters_Test.Item, {delay: 100});
-    cy.get('[data-cy="filter-brand"]').clear().type(Filters_Test.Brand, {delay: 100});
-    cy.get('[data-cy="filter-type"]').clear().type(Filters_Test.Type, {delay: 100});
-    cy.get('[data-cy="filter-size"]').clear().type(Filters_Test.Size, {delay: 100});
+    cy.get('[data-cy="filter-item"]').clear().type(Filters_Test.Item, {delay: 300});
+    cy.get('[data-cy="filter-brand"]').clear().type(Filters_Test.Brand, {delay: 300});
+    cy.get('[data-cy="filter-type"]').clear().type(Filters_Test.Type, {delay: 300});
+    cy.get('[data-cy="filter-size"]').clear().type(Filters_Test.Size, {delay: 300});
 
     // Wait for debounce (300ms) + buffer to ensure the final API call is made
     cy.wait(500);

--- a/client/cypress/e2e/inv.cy.ts
+++ b/client/cypress/e2e/inv.cy.ts
@@ -123,6 +123,8 @@ describe('Inventory', () => {
     cy.wait('@filterInventory');
     nextTick(1000);
 
+    cy.get(`[data-cy="inventory-table"]`).should('be.visible');
+
     cy.get(`[data-cy="inventory-item"]`) // Finds a cell that is an inventory-item
       .parent(`[data-cy="inventory-row"]`)             // Selects the parent row element
       .each(row => {            // Scopes subsequent commands to this row

--- a/client/cypress/support/inv.po.ts
+++ b/client/cypress/support/inv.po.ts
@@ -55,7 +55,7 @@ export class InventoryPage {
     return cy.get('[data-cy="inventory-paginator"]');
   }
   getInventoryRow() {
-    return cy.get('[data-cy="inventory-row"]');
+    return cy.get(`[data-cy="inventory-row"]`);
   }
   getInventoryFilterClear() {
     return cy.get('[data-cy="inventory-clear"]');

--- a/client/src/app/inventory/inventory.component.html
+++ b/client/src/app/inventory/inventory.component.html
@@ -83,7 +83,7 @@
   </div>
 </div>
 
-<table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8 demo-table">
+<table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8 demo-table" data-cy="inventory-table">
   <!-- Item Column -->
   <ng-container matColumnDef="item">
     <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by item">Item</th>


### PR DESCRIPTION
I tried over a dozen small differences in how the Cypress tests were written to try to get the one with filters to pass on GitHub. The actual problem was that the database was not seeded as part of the E2E process, so the GitHub workflow had no data. That made it so that anything actually checking the data on the page failed. The main thing that *should* have helped me see this was that changing the waiting time (increasing the wait time) to 15 times as much didn't fix it.

I'm still thinking that some of the ways I changed the intercept were useful. The last commit here includes all of the parameters in the cy.intercept, and I think that's much more elegant than any of the other waiting that I included previously. It might still be necessary to wait until the page loads, but I *think* that waiting for the request means we wait until the request gets a response. Therefore, I think that we would be covered by just the fancy intercept.